### PR TITLE
Bugfix for "[object Object]" cookies

### DIFF
--- a/dist/modal.js
+++ b/dist/modal.js
@@ -93,7 +93,7 @@ var bodModalBlock = function(){
 		if (this.$trigger.hasClass('type_selector')) {
 			var triggerSelector = this.$trigger.attr('data-selector');
 			if (triggerSelector) {
-				$('.' + triggerSelector).css('cursor','pointer').on('click', this.show); // attach click event
+				$('.' + triggerSelector).css('cursor','pointer').on('click', () => this.show()); // attach click event
 			}
 		} else if (this.$trigger.hasClass('type_load')) {
 			// we have show on page load
@@ -136,7 +136,7 @@ var bodModalBlock = function(){
 			}
 
 		} else { // must be button, text, or image trigger
-			this.$trigger.on('click', this.show); // attach click event
+			this.$trigger.on('click', () => this.show()); // attach click event
 		}
 
 		// setup the overlay and content wrap, put them into a jquery object and 


### PR DESCRIPTION
I was confused about this cookie on my website:
![image](https://github.com/merbird/modal-block/assets/23439797/3908ceed-7221-47c9-a075-2d21da07bc28)

It seems that the cookie functionality is only needed for modals of "type_load", but as the click event is passed to "this.show", loadOnce is defined for other modals, too – and a cookie is set unnecessarily.

This should fix it :)